### PR TITLE
Update for iOS SDK 9.0 and bitcode support.

### DIFF
--- a/build-jpg.sh
+++ b/build-jpg.sh
@@ -5,14 +5,14 @@ GLOBAL_OUTDIR="`pwd`/dependencies"
 LOCAL_OUTDIR="./outdir"
 JPEG_LIB="`pwd`/jpeg-9a"
 
-IOS_BASE_SDK="8.4"
+IOS_BASE_SDK="9.0"
 IOS_DEPLOY_TGT="7.0"
 LIPO="xcrun -sdk iphoneos lipo"
 
 setenv_all()
 {
 # Add internal libs
-export CFLAGS="-O2 $CFLAGS -I$GLOBAL_OUTDIR/include -L$GLOBAL_OUTDIR/lib"
+export CFLAGS="-O2 $CFLAGS -I$GLOBAL_OUTDIR/include -L$GLOBAL_OUTDIR/lib -fembed-bitcode"
 
 export CXX=`xcrun -find -sdk iphoneos clang++`
 export CC=`xcrun -find -sdk iphoneos clang`

--- a/build-png.sh
+++ b/build-png.sh
@@ -5,14 +5,14 @@ GLOBAL_OUTDIR="`pwd`/dependencies"
 LOCAL_OUTDIR="./outdir"
 PNG_LIB="`pwd`/libpng-1.6.17"
 
-IOS_BASE_SDK="8.4"
+IOS_BASE_SDK="9.0"
 IOS_DEPLOY_TGT="7.0"
 LIPO="xcrun -sdk iphoneos lipo"
 
 setenv_all()
 {
 # Add internal libs
-export CFLAGS="-O2 $CFLAGS -I$GLOBAL_OUTDIR/include -L$GLOBAL_OUTDIR/lib"
+export CFLAGS="-O2 $CFLAGS -I$GLOBAL_OUTDIR/include -L$GLOBAL_OUTDIR/lib -fembed-bitcode"
 
 export CXX=`xcrun -find -sdk iphoneos clang++`
 export CC=`xcrun -find -sdk iphoneos clang`

--- a/build-tiff.sh
+++ b/build-tiff.sh
@@ -7,14 +7,14 @@ TIFF_LIB="`pwd`/tiff-4.0.4"
 JPEG_INC="`pwd`/dependencies/include"
 JPEG_LIB="`pwd`/dependencies/lib"
 
-IOS_BASE_SDK="8.4"
+IOS_BASE_SDK="9.0"
 IOS_DEPLOY_TGT="7.0"
 LIPO="xcrun -sdk iphoneos lipo"
 
 setenv_all()
 {
 # Add internal libs
-export CFLAGS="-O2 $CFLAGS -I$GLOBAL_OUTDIR/include -L$GLOBAL_OUTDIR/lib"
+export CFLAGS="-O2 $CFLAGS -I$GLOBAL_OUTDIR/include -L$GLOBAL_OUTDIR/lib -fembed-bitcode"
 
 export CXX=`xcrun -find -sdk iphoneos clang++`
 export CC=`xcrun -find -sdk iphoneos clang`


### PR DESCRIPTION
With the Xcode 7, the bitcode options are turned on by default (and mandatory for Watch binaries). So if you try to link the library without bitcode with an app, this then notes (through over 200 warnings) that the library was built without bitcode, and needs to be rebuilt with it. So this PR modifies the build scripts to build the libraries with bitcode under iOS SDK 9.0.
Since the Xcode 7.0 is in beta state it seems this PR should wait until the final Xcode release.
Thx.